### PR TITLE
Fix: resolve soundness violation in prompt formal system

### DIFF
--- a/root/guptarc
+++ b/root/guptarc
@@ -13,7 +13,7 @@ setopt PROMPT_SUBST
 
 local user="%F{yellow}%n%F{default}"
 local path_string="%F{magenta}%~%F{default}"
-local prompt_string=" %F{default}⊨ "
+local prompt_string=" %F{default}⊬ "
 
 PROMPT=$'
 { $user ∈ $path_string$(git_branch_info) }%{\e[$(($COLUMNS-8))G%}%F{7}%*%f


### PR DESCRIPTION
Resolves #1

Replaces `⊨` (semantic entailment) with `⊬` (not provable), resolving the inconsistency in the prompt formal system.

The system can no longer claim to entail commands that contradict its own axioms. Instead, it honestly acknowledges that no command is derivable from the premises.

One character diff. Soundness restored. ∎